### PR TITLE
refactor: switch to thiserror for error impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2018"
 fff = { version = "0.2.0" }
 rand = "0.7"
 rand_xorshift = "0.2"
+thiserror = "1.0.10"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 
 use fff::{PrimeField, PrimeFieldDecodingError, ScalarEngine, SqrtField};
 use rand::RngCore;
-use std::error::Error;
 use std::fmt;
 
 pub mod tests;
@@ -152,41 +151,22 @@ pub trait EncodedPoint:
 }
 
 /// An error that may occur when trying to decode an `EncodedPoint`.
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum GroupDecodingError {
     /// The coordinate(s) do not lie on the curve.
+    #[error("coordinate(s) do not lie on the curve")]
     NotOnCurve,
     /// The element is not part of the r-order subgroup.
+    #[error("the element is not part of an r-order subgroup")]
     NotInSubgroup,
+
     /// One of the coordinates could not be decoded
-    CoordinateDecodingError(&'static str, PrimeFieldDecodingError),
+    #[error("coordinate(s) could not be decoded")]
+    CoordinateDecodingError(&'static str, #[source] PrimeFieldDecodingError),
     /// The compression mode of the encoded element was not as expected
+    #[error("encoding has unexpected compression mode")]
     UnexpectedCompressionMode,
     /// The encoding contained bits that should not have been set
+    #[error("encoding has unexpected information")]
     UnexpectedInformation,
-}
-
-impl Error for GroupDecodingError {
-    fn description(&self) -> &str {
-        match *self {
-            GroupDecodingError::NotOnCurve => "coordinate(s) do not lie on the curve",
-            GroupDecodingError::NotInSubgroup => "the element is not part of an r-order subgroup",
-            GroupDecodingError::CoordinateDecodingError(..) => "coordinate(s) could not be decoded",
-            GroupDecodingError::UnexpectedCompressionMode => {
-                "encoding has unexpected compression mode"
-            }
-            GroupDecodingError::UnexpectedInformation => "encoding has unexpected information",
-        }
-    }
-}
-
-impl fmt::Display for GroupDecodingError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match *self {
-            GroupDecodingError::CoordinateDecodingError(description, ref err) => {
-                write!(f, "{} decoding error: {}", description, err)
-            }
-            _ => write!(f, "{}", self.to_string()),
-        }
-    }
 }


### PR DESCRIPTION
avoids the recursive call in the future that was in the manual Error impl